### PR TITLE
Update Compiler.bat

### DIFF
--- a/Compiler.bat
+++ b/Compiler.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
 
 nasm -f win64 .\Assembly.asm -o .\Assembly.obj
-g++ -o cordyceps.exe main.cpp Assembly.obj
+g++ -o cordyceps.exe main.cpp Assembly.obj -static
 del *.obj


### PR DESCRIPTION
I think the '-static' argument will help increase compatibility and avoid the 'libstdc++-6 not found' error. It would also be beneficial to add the '-static-libgcc' and '-static-libstdc++' options for users who are compiling with MinGW instead of the GNU compiler.